### PR TITLE
Saltnado /run fix (#32590)

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -98,7 +98,7 @@ def start():
         http_server.bind(mod_opts['port'])
         http_server.start(mod_opts['num_processes'])
     except:
-        print 'Rest_tornado unable to bind to port {0}'.format(mod_opts['port'])
+        print('Rest_tornado unable to bind to port {0}'.format(mod_opts['port']))
         raise SystemExit(1)
 
     try:

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -211,7 +211,7 @@ class SaltClientsMixIn(object):
                 # not the actual client we'll use.. but its what we'll use to get args
                 'local_batch': local_client.cmd_batch,
                 'local_async': local_client.run_job,
-                'runner': salt.runner.RunnerClient(opts=self.application.opts).async,
+                'runner': salt.runner.RunnerClient(opts=self.application.opts).cmd_async,
                 }
         return SaltClientsMixIn.__saltclients
 
@@ -780,8 +780,6 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):
     def disbatch(self):
         '''
         Disbatch all lowstates to the appropriate clients
-
-        Auth must have been verified before this point
         '''
         ret = []
 
@@ -790,16 +788,23 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):
             client = low.get('client')
             self._verify_client(client)
 
-        for low in self.lowstate:
-            # make sure that the chunk has a token, if not we can't do auth per-request
-            # Note: this means that you can send different tokens per lowstate
-            # as long as the base token (to auth with the API) is valid
-            if 'token' not in low:
+            # Make sure we have 'token' or 'username'/'password' in each low chunk.
+            # Salt will verify the credentials are correct.
+            if self.token is not None and 'token' not in low:
                 low['token'] = self.token
+
+            if not (('token' in low)
+                    or ('username' in low and 'password' in low and 'eauth' in low)):
+                ret.append('Failed to authenticate')
+                break
+
             # disbatch to the correct handler
             try:
                 chunk_ret = yield getattr(self, '_disbatch_{0}'.format(low['client']))(low)
                 ret.append(chunk_ret)
+            except EauthAuthenticationError as exc:
+                ret.append('Failed to authenticate')
+                break
             except Exception as ex:
                 ret.append('Unexpected exception while handling request: {0}'.format(ex))
                 logger.error('Unexpected exception while handling request:', exc_info=True)
@@ -997,8 +1002,7 @@ class SaltAPIHandler(BaseSaltAPIHandler, SaltClientsMixIn):
         '''
         Disbatch runner client commands
         '''
-        f_call = {'args': [chunk['fun'], chunk]}
-        pub_data = self.saltclients['runner'](chunk['fun'], chunk)
+        pub_data = self.saltclients['runner'](chunk)
         tag = pub_data['tag'] + '/ret'
         try:
             event = yield self.application.event_listener.get_event(self, tag=tag)
@@ -1305,10 +1309,6 @@ class RunSaltAPIHandler(SaltAPIHandler):
                 ms-3: true
                 ms-4: true
         '''
-        if not self._verify_auth():
-            self.redirect('/login')
-            return
-
         self.disbatch()
 
 

--- a/tests/unit/netapi/rest_tornado/test_handlers.py
+++ b/tests/unit/netapi/rest_tornado/test_handlers.py
@@ -31,7 +31,7 @@ class SaltnadoTestCase(integration.ModuleCase, tornado.testing.AsyncHTTPTestCase
 
     @property
     def opts(self):
-        return self.get_config('master', from_scratch=True)
+        return self.get_config('client_config', from_scratch=True)
 
     @property
     def auth(self):


### PR DESCRIPTION
### What does this PR do?
### What issues does this PR fix or reference?
### Previous Behavior

Remove this section if not relevant
### New Behavior

Remove this section if not relevant
### Tests written?

Yes/No
- Revert "Verify auth in saltnado run (#32552)"

This reverts commit b19c5a5ce7dee098bb4a4c179a336659df5d4cbc.
- Call runner.cmd_async instead to enforce eauth
- Check for both token or user/pass before giving to Salt
- Remove comment as we're now enforcing auth here
- Lint and functionality fix courtesy of Mike P.
- Don't fail the whole request if there's an eauth problem
